### PR TITLE
Track project completion and clean up queues on finish

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -134,6 +134,7 @@ class Project(Base):
     name = Column(String, nullable=False)
     configuration = Column(JSON().with_variant(JSONB(), "postgresql"), nullable=False)
     created_at = Column(DateTime, nullable=False, server_default=func.now())
+    is_complete = Column(Boolean, nullable=False, default=False, server_default="false")
 
 
 class ProjectResult(Base):

--- a/src/routers/api/projects.py
+++ b/src/routers/api/projects.py
@@ -173,6 +173,8 @@ def get_project_status(
             detail="Project status temporarily unavailable",
         )
 
+    status_data["isFinished"] = project.is_complete
+
     return ProjectWithStatusResponse(
         id=project.id,
         user_id=project.user_id,

--- a/src/spawner/result_collector.py
+++ b/src/spawner/result_collector.py
@@ -5,7 +5,7 @@ from src.spawner.stop_service import stop_solver_controller
 from src.utils import solver_director_result_queue_name
 from src.database import SessionLocal
 from src.config import Config
-from src.models import ProjectResult
+from src.models import Project, ProjectResult
 
 
 logger = logging.getLogger(__name__)
@@ -43,6 +43,11 @@ async def result_collector():
                                 logger.warning(
                                     f"Failed to cleanup project {result_json.get('project_id')}: {cleanup_error}"
                                 )
+                            project = db.query(Project).filter(
+                                Project.id == result_json["project_id"]
+                            ).first()
+                            if project:
+                                project.is_complete = True
                             result_json.pop("final_message", None)
                             result_json.pop("total_messages", None)
 

--- a/src/spawner/stop_service.py
+++ b/src/spawner/stop_service.py
@@ -1,9 +1,38 @@
+import logging
+from urllib.parse import quote
+
+import requests
 from kubernetes import client, config
+
+from src.config import Config
 from src.utils import solvers_namespace
+
+logger = logging.getLogger(__name__)
 
 
 def stop_solver_controller(namespace):
-    config.load_incluster_config()  # Load k8s config to use mounted service account
+    config.load_incluster_config()
     kube_client = client.CoreV1Api()
     kube_client.delete_namespace(namespace)
     kube_client.delete_namespace(solvers_namespace(namespace))
+    delete_project_queues(namespace)
+
+
+def delete_project_queues(project_id):
+    management_url = f"http://{Config.RabbitMQ.HOST}:{Config.RabbitMQ.MANAGEMENT_PORT}"
+    auth = (Config.RabbitMQ.USER, Config.RabbitMQ.PASSWORD)
+
+    queues = requests.get(f"{management_url}/api/queues/%2F", auth=auth, timeout=10).json()
+
+    project_prefix = f"project-{project_id}-"
+    for queue in queues:
+        if queue["name"].startswith(project_prefix):
+            response = requests.delete(
+                f"{management_url}/api/queues/%2F/{quote(queue['name'], safe='')}",
+                auth=auth,
+                timeout=10,
+            )
+            if response.ok:
+                logger.info(f"Deleted queue: {queue['name']}")
+            else:
+                logger.warning(f"Failed to delete queue {queue['name']}: {response.status_code}")


### PR DESCRIPTION
## Summary
- Add `is_complete` boolean field to the `Project` model
- Expose `isFinished` via the status endpoint using `project.is_complete` (overrides the solver controller's value once the project is finished)
- Mark projects as complete in the result collector when a final result is received
- Delete RabbitMQ project queues when a project is stopped via `delete_project_queues`

## Test plan
- [ ] CI passes (tests and bandit audit)
- [ ] Verify `GET /v1/projects/{id}/status` returns `isFinished: true` after the solver finishes
- [ ] Verify RabbitMQ queues are cleaned up after a project is deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)