### PR TITLE
Remove Harbor, switch to GitHub Container Registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,6 @@ FROM python:3.13-slim AS base
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
-# Install skopeo for pushing Docker images to Harbor
-RUN apt-get update && apt-get install -y \
-    skopeo \
-    && rm -rf /var/lib/apt/lists/*
-
 RUN useradd -u 10001 -m appuser
 
 WORKDIR /home/appuser/app

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -23,9 +23,6 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: solver-director
-      imagePullSecrets:
-      - name: harbor-creds-pull
-
       securityContext:
         runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
         seccompProfile:
@@ -126,6 +123,10 @@ spec:
               value: {{ .Values.resourceLimitDefaults.globalMaxCpuCores | quote }}
             - name: DEFAULT_GLOBAL_MAX_MEMORY_GIB
               value: {{ .Values.resourceLimitDefaults.globalMaxMemoryGib | quote }}
+            - name: SOLVER_CONTROLLER_IMAGE
+              value: {{ .Values.solverController.image | quote }}
+            - name: DATA_GATHERER_IMAGE
+              value: {{ .Values.dataGatherer.image | quote }}
             - name: KEYCLOAK_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/helm/templates/service-account.yaml
+++ b/helm/templates/service-account.yaml
@@ -4,8 +4,6 @@ kind: ServiceAccount
 metadata:
   name: solver-director
   namespace: psp
-imagePullSecrets:
-- name: harbor-creds-pull
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -18,9 +16,6 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["create"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["create", "get"]
 - apiGroups: [""]
   resources: ["services"]
   verbs: ["create"]

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -108,6 +108,12 @@ postgres:
     size: "1Gi"
     storageClass: "postgres-retain"
 
+solverController:
+  image: "ghcr.io/portfolio-solver-platform/solver-controller:latest"
+
+dataGatherer:
+  image: "ghcr.io/portfolio-solver-platform/data-gatherer:latest"
+
 resourceLimitDefaults:
   perUserCpuCores: "8"
   perUserMemoryGib: "32"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -25,8 +25,10 @@ profiles:
             namespace: psp
             setValueTemplates:
               image: "{{.IMAGE_FULLY_QUALIFIED}}"
+              solverController.image: "{{if .SOLVER_CONTROLLER_IMAGE}}{{.SOLVER_CONTROLLER_IMAGE}}{{else}}ghcr.io/portfolio-solver-platform/solver-controller:latest{{end}}"
+              dataGatherer.image: "{{if .DATA_GATHERER_IMAGE}}{{.DATA_GATHERER_IMAGE}}{{else}}ghcr.io/portfolio-solver-platform/data-gatherer:latest{{end}}"
 
-          
+
 
   - name: staging
     build:

--- a/src/config.py
+++ b/src/config.py
@@ -13,23 +13,14 @@ class Config:
         VERSION = "v1"
         ROOT_PATH = "/api/solverdirector"
 
-    class ArtifactRegistry:
-        EXTERNAL_URL = os.getenv("EXTERNAL_ARTIFACT_REGISTRY_URL", "harbor.local/")
-        # Internal registry URL for skopeo (defaults to harbor-core service)
-        INTERNAL_URL = os.getenv(
-            "INTERNAL_ARTIFACT_REGISTRY_URL", "harbor-core.harbor.svc.cluster.local/"
-        )
-        PROJECT = "psp-solvers"
-        TLS_VERIFY = os.getenv("HARBOR_TLS_VERIFY", "false") == "true"
-
     class SolverController:
-        ARTIFACT_REGISTRY_PATH = "psp/solver-controller:latest"
+        IMAGE = os.getenv("SOLVER_CONTROLLER_IMAGE", "ghcr.io/portfolio-solver-platform/solver-controller:latest")
         SVC_NAME = "solver-controller"
         CONTAINER_PORT = 8080
         SERVICE_PORT = 80
 
     class DataGatherer:
-        ARTIFACT_REGISTRY_PATH = "psp/data-gatherer:latest"
+        IMAGE = os.getenv("DATA_GATHERER_IMAGE", "ghcr.io/portfolio-solver-platform/data-gatherer:latest")
         SVC_NAME = "data-gatherer"
         CONTAINER_PORT = 8080
         SERVICE_PORT = 80

--- a/src/routers/api/solvers.py
+++ b/src/routers/api/solvers.py
@@ -1,19 +1,11 @@
 from typing import Annotated
-from fastapi import APIRouter, HTTPException, Depends, UploadFile, File, Form, status
+from fastapi import APIRouter, HTTPException, Depends, Form, status
 from sqlalchemy.orm import Session
 from pydantic import BaseModel, ConfigDict, Field
-import asyncio
 import re
-import json
-import base64
-import tempfile
-import os
-from kubernetes import client, config as k8s_config
-from prometheus_client import Counter
 
 from src.database import get_db
 from src.models import Solver, SolverImage
-from src.config import Config
 from src.auth import auth
 
 
@@ -27,52 +19,6 @@ SCOPES = {
 # Must start with lowercase letter or digit, followed by lowercase alphanumeric, dots, hyphens, or underscores
 # Max length: 128 characters
 VALID_IMAGE_NAME = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
-
-# Prometheus metrics
-temp_file_cleanup_failures = Counter(
-    "solver_director_temp_file_cleanup_failures_total",
-    "Total number of temporary file cleanup failures",
-    ["operation"],
-)
-
-
-def get_harbor_credentials(secret_name: str = "harbor-creds-push"):  # nosec B107
-    """Reads Harbor credentials from a Kubernetes secret
-
-    Args:
-        secret_name: Name of the Harbor credentials secret (default: harbor-creds-push)
-
-    Returns:
-        Tuple of (username, password) for Harbor authentication
-
-    Note:
-        The default parameter is a Kubernetes secret name (resource identifier),
-        not a hardcoded password. Actual credentials are retrieved from K8s at runtime.
-    """
-    try:
-        k8s_config.load_incluster_config()
-        kube_client = client.CoreV1Api()
-
-        secret = kube_client.read_namespaced_secret(name=secret_name, namespace="psp")
-
-        # Docker config secrets store credentials in .dockerconfigjson
-        docker_config_json = base64.b64decode(secret.data[".dockerconfigjson"]).decode(
-            "utf-8"
-        )
-        docker_config = json.loads(docker_config_json)
-
-        # Extract credentials for harbor.local
-        auth_config = docker_config.get("auths", {}).get("harbor.local", {})
-        auth_string = auth_config.get("auth", "")
-
-        username, password = base64.b64decode(auth_string).decode("utf-8").split(":", 1)
-
-        return username, password
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to get Harbor credentials: {str(e)}",
-        )
 
 
 class StartResponse(BaseModel):
@@ -178,9 +124,12 @@ scopes = [SCOPES["write"]]
     # dependencies=[auth.require_scopes(scopes)],
     # openapi_extra=auth.scope_docs(scopes),
 )
-async def upload_solver(
+def register_solver(
     image_name: Annotated[
-        str, Form(description="Docker image name for Harbor (e.g., 'minizinc-solver')")
+        str, Form(description="Short image name (e.g., 'minizinc-solvers')")
+    ],
+    image_url: Annotated[
+        str, Form(description="Full image URL (e.g., 'ghcr.io/portfolio-solver-platform/minizinc-solvers:latest')")
     ],
     names: Annotated[
         str,
@@ -188,19 +137,9 @@ async def upload_solver(
             description="Comma-separated solver names (e.g., 'chuffed,gecode,ortools')"
         ),
     ],
-    file: Annotated[UploadFile, File(description="Docker image tarball (.tar file)")],
     db: Annotated[Session, Depends(get_db)],
 ):
-    """Upload a Docker image tarball and push to Harbor
-
-    Args:
-        image_name: Docker image name for Harbor (e.g., "minizinc-solver")
-        names: Comma-separated solver names that this image supports (e.g., "chuffed,gecode,ortools")
-        file: Docker image tarball (.tar file)
-
-    Returns:
-        SolverResponse with solver metadata including Harbor image path
-    """
+    """Register a solver image by its registry URL."""
     normalized_image_name = image_name.strip().lower()
     if not normalized_image_name:
         raise HTTPException(
@@ -212,6 +151,12 @@ async def upload_solver(
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="Image name must be lowercase alphanumeric, may contain dots, hyphens, or underscores, and must start with a letter or digit",
+        )
+
+    if not image_url.strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Image URL cannot be empty",
         )
 
     name_list = [n.strip().lower() for n in names.split(",") if n.strip()]
@@ -239,69 +184,9 @@ async def upload_solver(
             detail=f"Solver image '{normalized_image_name}' already exists",
         )
 
-    if not file:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="File is required"
-        )
-
-    file_data = await file.read()
-    if not file_data:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail="File cannot be empty",
-        )
-
-    tarball_path = None
     try:
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".tar") as tmp:
-            tmp.write(file_data)
-            tarball_path = tmp.name
-
-        username, password = get_harbor_credentials()
-
-        registry_image_name = f"{Config.ArtifactRegistry.INTERNAL_URL}{Config.ArtifactRegistry.PROJECT}/{normalized_image_name}:latest"
-        external_image_name = f"{Config.ArtifactRegistry.EXTERNAL_URL}{Config.ArtifactRegistry.PROJECT}/{normalized_image_name}:latest"
-
-        skopeo_args = [
-            "skopeo",
-            "copy",
-            f"docker-archive:{tarball_path}",
-            f"docker://{registry_image_name}",
-            "--dest-creds",
-            f"{username}:{password}",
-        ]
-
-        if not Config.ArtifactRegistry.TLS_VERIFY:
-            skopeo_args.append("--dest-tls-verify=false")
-
-        # Safe: subprocess uses list args (no shell), Harbor RBAC restricts push to psp-solvers project only
-        # nosec B603
-        process = await asyncio.create_subprocess_exec(
-            *skopeo_args, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
-        )
-
-        try:
-            stdout, stderr = await asyncio.wait_for(
-                process.communicate(),
-                timeout=300,  # 5 minute timeout
-            )
-        except asyncio.TimeoutError:
-            process.kill()
-            await process.wait()
-            db.rollback()
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Image push timed out",
-            )
-
-        if process.returncode != 0:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"Failed to push image to Harbor: {stderr.decode('utf-8')}",
-            )
-
         solver_image = SolverImage(
-            image_name=normalized_image_name, image_path=external_image_name
+            image_name=normalized_image_name, image_path=image_url.strip()
         )
         db.add(solver_image)
         db.flush()
@@ -317,7 +202,7 @@ async def upload_solver(
             id=solver_image.id,
             names=name_list,
             solver_images_id=solver_image.id,
-            image_path=external_image_name,
+            image_path=image_url.strip(),
         )
 
     except HTTPException:
@@ -327,11 +212,47 @@ async def upload_solver(
         db.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to upload solver: {str(e)}",
+            detail=f"Failed to register solver: {str(e)}",
         )
-    finally:
-        if tarball_path and os.path.exists(tarball_path):
-            try:
-                os.unlink(tarball_path)
-            except Exception:
-                temp_file_cleanup_failures.labels(operation="solver_upload").inc()
+
+
+@router.patch(
+    "/solvers/images/{image_name}",
+    response_model=SolverUploadResponse,
+    # TODO: re-enable auth once setup scripts have service account credentials
+    # dependencies=[auth.require_scopes([SCOPES["write"]])],
+    # openapi_extra=auth.scope_docs([SCOPES["write"]]),
+)
+def update_solver_image_url(
+    image_name: str,
+    image_url: Annotated[str, Form(description="New full image URL")],
+    db: Annotated[Session, Depends(get_db)],
+):
+    """Update the image URL for an existing solver image by name."""
+    solver_image = (
+        db.query(SolverImage)
+        .filter(SolverImage.image_name == image_name.strip().lower())
+        .first()
+    )
+    if not solver_image:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Solver image '{image_name}' not found",
+        )
+
+    if not image_url.strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Image URL cannot be empty",
+        )
+
+    solver_image.image_path = image_url.strip()
+    db.commit()
+    db.refresh(solver_image)
+
+    return SolverUploadResponse(
+        id=solver_image.id,
+        names=[s.name for s in solver_image.solvers],
+        solver_images_id=solver_image.id,
+        image_path=solver_image.image_path,
+    )

--- a/src/spawner/start_service.py
+++ b/src/spawner/start_service.py
@@ -54,27 +54,6 @@ def start_project_services(project_config, id, user_id):
         else:
             raise
 
-    template_secret = kube_client.read_namespaced_secret(
-        name="harbor-creds-pull", namespace="psp"
-    )
-
-    # create 2 namespaces. One for infrastructure for project and the Data Gatherer/AI. Another namepace for the solvers themselves.
-    control_secret = client.V1Secret(
-        metadata=client.V1ObjectMeta(name="harbor-creds", namespace=id),
-        type=template_secret.type,
-        data=template_secret.data,
-    )
-    kube_client.create_namespaced_secret(namespace=id, body=control_secret)
-
-    solvers_secret = client.V1Secret(
-        metadata=client.V1ObjectMeta(name="harbor-creds", namespace=_solvers_namespace),
-        type=template_secret.type,
-        data=template_secret.data,
-    )
-    kube_client.create_namespaced_secret(
-        namespace=_solvers_namespace, body=solvers_secret
-    )
-
     # Create Role in solvers namespace to allow creating deployments and scaledobjects
     role = client.V1Role(
         metadata=client.V1ObjectMeta(
@@ -219,7 +198,6 @@ def create_solver_controller_pod_manifest(project_id, control_queue, result_queu
             "labels": {"solver_controller_id": "solver-controller"},
         },
         "spec": {
-            "imagePullSecrets": [{"name": "harbor-creds"}],
             "securityContext": {
                 "runAsNonRoot": True,
                 "seccompProfile": {"type": "RuntimeDefault"},
@@ -227,7 +205,7 @@ def create_solver_controller_pod_manifest(project_id, control_queue, result_queu
             "containers": [
                 {
                     "name": "solver-controller",
-                    "image": f"{Config.ArtifactRegistry.EXTERNAL_URL}{Config.SolverController.ARTIFACT_REGISTRY_PATH}",
+                    "image": Config.SolverController.IMAGE,
                     "imagePullPolicy": "IfNotPresent",
                     "ports": [
                         {"containerPort": Config.SolverController.CONTAINER_PORT}
@@ -312,7 +290,6 @@ def create_data_gatherer_pod_manifest(
             "labels": {"data_gatherer_id": "data-gatherer"},
         },
         "spec": {
-            "imagePullSecrets": [{"name": "harbor-creds"}],
             "securityContext": {
                 "runAsNonRoot": True,
                 "seccompProfile": {"type": "RuntimeDefault"},
@@ -320,7 +297,7 @@ def create_data_gatherer_pod_manifest(
             "containers": [
                 {
                     "name": "data-gatherer",
-                    "image": f"{Config.ArtifactRegistry.EXTERNAL_URL}{Config.DataGatherer.ARTIFACT_REGISTRY_PATH}",
+                    "image": Config.DataGatherer.IMAGE,
                     "imagePullPolicy": "IfNotPresent",
                     "ports": [{"containerPort": Config.DataGatherer.CONTAINER_PORT}],
                     "env": [

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -209,7 +209,7 @@ def test_update_group_solvers_only(authed_client_with_db, test_db):
 
     # Create solvers
     solver_image1 = SolverImage(
-        image_name="solver1", image_path="harbor.local/psp-solvers/solver1:latest"
+        image_name="solver1", image_path="ghcr.io/portfolio-solver-platform/solver1:latest"
     )
     test_db.add(solver_image1)
     test_db.flush()
@@ -218,7 +218,7 @@ def test_update_group_solvers_only(authed_client_with_db, test_db):
     test_db.add(solver1)
 
     solver_image2 = SolverImage(
-        image_name="solver2", image_path="harbor.local/psp-solvers/solver2:latest"
+        image_name="solver2", image_path="ghcr.io/portfolio-solver-platform/solver2:latest"
     )
     test_db.add(solver_image2)
     test_db.flush()
@@ -249,7 +249,7 @@ def test_update_group_all_fields(authed_client_with_db, test_db):
 
     # Create solver
     solver_image = SolverImage(
-        image_name="solver", image_path="harbor.local/psp-solvers/solver:latest"
+        image_name="solver", image_path="ghcr.io/portfolio-solver-platform/solver:latest"
     )
     test_db.add(solver_image)
     test_db.flush()
@@ -343,7 +343,7 @@ def test_update_group_duplicate_solver_ids(authed_client_with_db, test_db):
 
     # Create solver
     solver_image = SolverImage(
-        image_name="solver", image_path="harbor.local/psp-solvers/solver:latest"
+        image_name="solver", image_path="ghcr.io/portfolio-solver-platform/solver:latest"
     )
     test_db.add(solver_image)
     test_db.flush()

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1,406 +1,129 @@
 """Tests for solvers API endpoints"""
 
-import asyncio
-import io
-from unittest.mock import Mock, patch
 from src.models import Solver, SolverImage
 
-
-def create_mock_process(returncode=0, stdout=b"Success", stderr=b""):
-    """Helper to create a mock async subprocess"""
-    mock_process = Mock()
-    mock_process.returncode = returncode
-
-    async def _communicate():
-        return (stdout, stderr)
-
-    async def _wait():
-        return None
-
-    mock_process.communicate = _communicate
-    mock_process.wait = _wait
-    mock_process.kill = Mock()
-    return mock_process
+IMAGE_URL = "ghcr.io/portfolio-solver-platform/minizinc-solvers:latest"
 
 
-def test_upload_solver_success(authed_client_with_db):
-    """Test uploading a solver successfully"""
-    fake_tarball = io.BytesIO(b"fake docker image tar data")
-
-    with (
-        patch("src.routers.api.solvers.asyncio.create_subprocess_exec") as mock_exec,
-        patch("src.routers.api.solvers.get_harbor_credentials") as mock_creds,
-    ):
-        mock_creds.return_value = ("test-user", "test-pass")
-        mock_exec.return_value = create_mock_process(returncode=0)
-
-        response = authed_client_with_db.post(
-            "/api/solverdirector/v1/solvers",
-            data={"image_name": "minizinc-solver", "names": "chuffed,gecode"},
-            files={"file": ("minizinc.tar", fake_tarball, "application/x-tar")},
-        )
-
-        assert response.status_code == 201
-        data = response.json()
-        assert data["names"] == ["chuffed", "gecode"]
-        assert data["id"] == 1
-        assert data["solver_images_id"] == 1
-        assert data["image_path"] == "harbor.local/psp-solvers/minizinc-solver:latest"
-
-        mock_exec.assert_called_once()
-        call_args = mock_exec.call_args[0]
-        assert call_args[0] == "skopeo"
-        assert call_args[1] == "copy"
-        assert call_args[2].startswith("docker-archive:")
-        assert (
-            call_args[3]
-            == "docker://harbor-core.harbor.svc.cluster.local/psp-solvers/minizinc-solver:latest"
-        )
-        assert "--dest-creds" in call_args
-        assert "test-user:test-pass" in call_args
-
-
-def test_upload_solver_duplicate_image_name(authed_client_with_db):
-    """Test uploading a solver with duplicate image_name fails"""
-    fake_tarball = io.BytesIO(b"fake tar data")
-
-    with (
-        patch("src.routers.api.solvers.asyncio.create_subprocess_exec") as mock_exec,
-        patch("src.routers.api.solvers.get_harbor_credentials") as mock_creds,
-    ):
-        mock_creds.return_value = ("test-user", "test-pass")
-        mock_exec.return_value = create_mock_process(returncode=0)
-
-        authed_client_with_db.post(
-            "/api/solverdirector/v1/solvers",
-            data={"image_name": "minizinc-solver", "names": "chuffed"},
-            files={
-                "file": (
-                    "minizinc.tar",
-                    io.BytesIO(b"fake tar data"),
-                    "application/x-tar",
-                )
-            },
-        )
-
-        response = authed_client_with_db.post(
-            "/api/solverdirector/v1/solvers",
-            data={"image_name": "minizinc-solver", "names": "gecode"},
-            files={"file": ("minizinc2.tar", fake_tarball, "application/x-tar")},
-        )
-
-        assert response.status_code == 400
-        assert "already exists" in response.json()["detail"]
-
-
-def test_upload_solver_empty_image_name(authed_client_with_db):
-    """Test uploading a solver with empty image_name fails"""
-    fake_tarball = io.BytesIO(b"fake tar data")
-
-    response = authed_client_with_db.post(
+def _register(client, image_name="minizinc-solvers", image_url=IMAGE_URL, names="chuffed,gecode"):
+    return client.post(
         "/api/solverdirector/v1/solvers",
-        data={"image_name": "   ", "names": "gecode"},  # Whitespace only
-        files={"file": ("solver.tar", fake_tarball, "application/x-tar")},
+        data={"image_name": image_name, "image_url": image_url, "names": names},
     )
 
+
+def test_register_solver_success(authed_client_with_db):
+    response = _register(authed_client_with_db)
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["names"] == ["chuffed", "gecode"]
+    assert data["id"] == 1
+    assert data["solver_images_id"] == 1
+    assert data["image_path"] == IMAGE_URL
+
+
+def test_register_solver_creates_database_records(authed_client_with_db, test_db):
+    response = _register(authed_client_with_db, names="chuffed,gecode")
+    assert response.status_code == 201
+
+    solver_image = (
+        test_db.query(SolverImage)
+        .filter(SolverImage.image_name == "minizinc-solvers")
+        .first()
+    )
+    assert solver_image is not None
+    assert solver_image.image_path == IMAGE_URL
+
+    for name in ["chuffed", "gecode"]:
+        solver = test_db.query(Solver).filter(Solver.name == name).first()
+        assert solver is not None
+        assert solver.solver_image_id == solver_image.id
+
+
+def test_register_solver_duplicate_image_name(authed_client_with_db):
+    _register(authed_client_with_db)
+    response = _register(authed_client_with_db)
+
+    assert response.status_code == 400
+    assert "already exists" in response.json()["detail"]
+
+
+def test_register_solver_empty_image_name(authed_client_with_db):
+    response = _register(authed_client_with_db, image_name="   ")
     assert response.status_code == 422
     assert "cannot be empty" in response.json()["detail"]
 
 
-def test_upload_solver_empty_names(authed_client_with_db):
-    """Test uploading a solver with empty names fails"""
-    fake_tarball = io.BytesIO(b"fake tar data")
+def test_register_solver_empty_image_url(authed_client_with_db):
+    response = _register(authed_client_with_db, image_url="   ")
+    assert response.status_code == 422
+    assert "cannot be empty" in response.json()["detail"]
 
-    response = authed_client_with_db.post(
-        "/api/solverdirector/v1/solvers",
-        data={"image_name": "minizinc-solver", "names": "   "},  # Whitespace only
-        files={"file": ("solver.tar", fake_tarball, "application/x-tar")},
-    )
 
+def test_register_solver_empty_names(authed_client_with_db):
+    response = _register(authed_client_with_db, names="   ")
     assert response.status_code == 422
     assert "At least one solver name is required" in response.json()["detail"]
 
 
-def test_upload_solver_empty_file(authed_client_with_db):
-    """Test uploading a solver with empty file fails"""
-    empty_file = io.BytesIO(b"")
-
-    response = authed_client_with_db.post(
-        "/api/solverdirector/v1/solvers",
-        data={"image_name": "minizinc-solver", "names": "gecode"},
-        files={"file": ("gecode.tar", empty_file, "application/x-tar")},
+def test_register_solver_normalizes_names(authed_client_with_db):
+    response = _register(
+        authed_client_with_db,
+        image_name="  MiniZinc-Solvers  ",
+        names="  Chuffed , GECODE  ",
     )
-
-    assert response.status_code == 422
-    assert "cannot be empty" in response.json()["detail"]
-
-
-def test_upload_solver_missing_file(authed_client_with_db):
-    """Test uploading a solver without file fails"""
-    response = authed_client_with_db.post(
-        "/api/solverdirector/v1/solvers",
-        data={"image_name": "minizinc-solver", "names": "gecode"},
-    )
-
-    assert response.status_code == 422
+    assert response.status_code == 201
+    data = response.json()
+    assert data["names"] == ["chuffed", "gecode"]
 
 
-def test_upload_solver_harbor_push_failure(authed_client_with_db):
-    """Test handling Harbor push failure"""
-    fake_tarball = io.BytesIO(b"fake tar data")
-
-    with (
-        patch("src.routers.api.solvers.asyncio.create_subprocess_exec") as mock_exec,
-        patch("src.routers.api.solvers.get_harbor_credentials") as mock_creds,
-    ):
-        mock_creds.return_value = ("test-user", "test-pass")
-        mock_exec.return_value = create_mock_process(
-            returncode=1, stderr=b"Error: failed to push to Harbor", stdout=b""
-        )
-
-        response = authed_client_with_db.post(
-            "/api/solverdirector/v1/solvers",
-            data={"image_name": "minizinc-solver", "names": "gecode"},
-            files={"file": ("gecode.tar", fake_tarball, "application/x-tar")},
-        )
-
-        assert response.status_code == 500
-        assert "Failed to push image to Harbor" in response.json()["detail"]
-
-
-def test_upload_solver_harbor_credentials_failure(authed_client_with_db):
-    """Test handling Harbor credentials failure"""
-    fake_tarball = io.BytesIO(b"fake tar data")
-
-    with patch("src.routers.api.solvers.get_harbor_credentials") as mock_creds:
-        mock_creds.side_effect = Exception("Failed to get credentials")
-
-        response = authed_client_with_db.post(
-            "/api/solverdirector/v1/solvers",
-            data={"image_name": "minizinc-solver", "names": "gecode"},
-            files={"file": ("gecode.tar", fake_tarball, "application/x-tar")},
-        )
-
-        assert response.status_code == 500
-        assert "Failed to upload solver" in response.json()["detail"]
-
-
-def test_upload_solver_timeout(authed_client_with_db):
-    """Test handling skopeo timeout"""
-    fake_tarball = io.BytesIO(b"fake tar data")
-
-    with (
-        patch("src.routers.api.solvers.asyncio.create_subprocess_exec") as mock_exec,
-        patch("src.routers.api.solvers.asyncio.wait_for") as mock_wait_for,
-        patch("src.routers.api.solvers.get_harbor_credentials") as mock_creds,
-    ):
-        mock_creds.return_value = ("test-user", "test-pass")
-        # communicate is never awaited (wait_for raises before it runs), so use a plain
-        # Mock to avoid creating an unawaited coroutine that leaks into the next test's GC.
-        mock_process = create_mock_process(returncode=0)
-        mock_process.communicate = Mock(return_value=None)
-        mock_exec.return_value = mock_process
-        mock_wait_for.side_effect = asyncio.TimeoutError()
-
-        response = authed_client_with_db.post(
-            "/api/solverdirector/v1/solvers",
-            data={"image_name": "minizinc-solver", "names": "gecode"},
-            files={"file": ("gecode.tar", fake_tarball, "application/x-tar")},
-        )
-
-        assert response.status_code == 500
-        assert "timed out" in response.json()["detail"]
-
-
-def test_upload_solver_creates_database_records(authed_client_with_db, test_db):
-    """Test that solver upload creates correct database records"""
-    fake_tarball = io.BytesIO(b"fake tar data")
-
-    with (
-        patch("src.routers.api.solvers.asyncio.create_subprocess_exec") as mock_exec,
-        patch("src.routers.api.solvers.get_harbor_credentials") as mock_creds,
-    ):
-        mock_creds.return_value = ("test-user", "test-pass")
-        mock_exec.return_value = create_mock_process(returncode=0)
-
-        response = authed_client_with_db.post(
-            "/api/solverdirector/v1/solvers",
-            data={"image_name": "minizinc-solver", "names": "chuffed,gecode"},
-            files={"file": ("minizinc.tar", fake_tarball, "application/x-tar")},
-        )
-
-        assert response.status_code == 201
-
-        # Check SolverImage record
-        solver_image = (
-            test_db.query(SolverImage)
-            .filter(SolverImage.image_name == "minizinc-solver")
-            .first()
-        )
-        assert solver_image is not None
-        assert solver_image.image_name == "minizinc-solver"
-        assert (
-            solver_image.image_path == "harbor.local/psp-solvers/minizinc-solver:latest"
-        )
-
-        # Check that both Solver records were created
-        chuffed_solver = test_db.query(Solver).filter(Solver.name == "chuffed").first()
-        assert chuffed_solver is not None
-        assert chuffed_solver.name == "chuffed"
-        assert chuffed_solver.solver_image_id == solver_image.id
-
-        gecode_solver = test_db.query(Solver).filter(Solver.name == "gecode").first()
-        assert gecode_solver is not None
-        assert gecode_solver.name == "gecode"
-        assert gecode_solver.solver_image_id == solver_image.id
-
-
-def test_upload_solver_normalizes_names(authed_client_with_db):
-    """Test that image_name and solver names are normalized (whitespace stripped and lowercased)"""
-    fake_tarball = io.BytesIO(b"fake tar data")
-
-    with (
-        patch("src.routers.api.solvers.asyncio.create_subprocess_exec") as mock_exec,
-        patch("src.routers.api.solvers.get_harbor_credentials") as mock_creds,
-    ):
-        mock_creds.return_value = ("test-user", "test-pass")
-        mock_exec.return_value = create_mock_process(returncode=0)
-
-        response = authed_client_with_db.post(
-            "/api/solverdirector/v1/solvers",
-            data={"image_name": "  MiniZinc-Solver  ", "names": "  Chuffed , GECODE  "},
-            files={"file": ("minizinc.tar", fake_tarball, "application/x-tar")},
-        )
-
-        assert response.status_code == 201
-        data = response.json()
-        assert data["names"] == ["chuffed", "gecode"]
-        assert data["image_path"] == "harbor.local/psp-solvers/minizinc-solver:latest"
-
-
-def test_upload_solver_invalid_image_name(authed_client_with_db):
-    """Test that invalid image names are rejected"""
-    fake_tarball = io.BytesIO(b"fake tar data")
-
-    invalid_names = [
-        "gecode/nested",
-        "../gecode",
-        "gecode@latest",
-        "-gecode",
-        ".gecode",
-        "ge code",
-    ]
-
-    for invalid_name in invalid_names:
-        response = authed_client_with_db.post(
-            "/api/solverdirector/v1/solvers",
-            data={"image_name": invalid_name, "names": "chuffed"},
-            files={"file": ("solver.tar", fake_tarball, "application/x-tar")},
-        )
-
-        assert response.status_code == 422, (
-            f"Expected 422 for image_name: {invalid_name}, got {response.status_code}: {response.json()}"
-        )
+def test_register_solver_invalid_image_name(authed_client_with_db):
+    for invalid_name in ["gecode/nested", "../gecode", "gecode@latest", "-gecode", ".gecode", "ge code"]:
+        response = _register(authed_client_with_db, image_name=invalid_name)
+        assert response.status_code == 422, f"Expected 422 for: {invalid_name}"
         assert "lowercase alphanumeric" in response.json()["detail"]
 
 
-def test_upload_solver_invalid_solver_names(authed_client_with_db):
-    """Test that invalid solver names in the names parameter are rejected"""
-    fake_tarball = io.BytesIO(b"fake tar data")
-
-    invalid_names = [
-        "chuffed/nested",
-        "../chuffed",
-        "chuffed@latest",
-        "-chuffed",
-        ".chuffed",
-    ]
-
-    for invalid_name in invalid_names:
-        response = authed_client_with_db.post(
-            "/api/solverdirector/v1/solvers",
-            data={"image_name": "minizinc-solver", "names": invalid_name},
-            files={"file": ("solver.tar", fake_tarball, "application/x-tar")},
-        )
-
-        assert response.status_code == 422, (
-            f"Expected 422 for solver name: {invalid_name}, got {response.status_code}: {response.json()}"
-        )
+def test_register_solver_invalid_solver_names(authed_client_with_db):
+    for invalid_name in ["chuffed/nested", "../chuffed", "chuffed@latest", "-chuffed", ".chuffed"]:
+        response = _register(authed_client_with_db, names=invalid_name)
+        assert response.status_code == 422, f"Expected 422 for: {invalid_name}"
         assert "lowercase alphanumeric" in response.json()["detail"]
 
 
-def test_get_all_solvers(authed_client_with_db, test_db):
-    """Test retrieving all solvers"""
-    fake_tarball = io.BytesIO(b"fake tar data")
+def test_get_all_solvers(authed_client_with_db):
+    _register(authed_client_with_db, names="chuffed,gecode,ortools")
 
-    with (
-        patch("src.routers.api.solvers.asyncio.create_subprocess_exec") as mock_exec,
-        patch("src.routers.api.solvers.get_harbor_credentials") as mock_creds,
-    ):
-        mock_creds.return_value = ("test-user", "test-pass")
-        mock_exec.return_value = create_mock_process(returncode=0)
+    response = authed_client_with_db.get("/api/solverdirector/v1/solvers")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["solvers"]) == 3
 
-        authed_client_with_db.post(
-            "/api/solverdirector/v1/solvers",
-            data={"image_name": "minizinc-solver", "names": "chuffed,gecode,ortools"},
-            files={"file": ("minizinc.tar", fake_tarball, "application/x-tar")},
-        )
+    solver_names = {s["name"] for s in data["solvers"]}
+    assert solver_names == {"chuffed", "gecode", "ortools"}
 
-        response = authed_client_with_db.get("/api/solverdirector/v1/solvers")
-
-        assert response.status_code == 200
-        data = response.json()
-        assert "solvers" in data
-        assert len(data["solvers"]) == 3
-
-        solver_names = {solver["name"] for solver in data["solvers"]}
-        assert solver_names == {"chuffed", "gecode", "ortools"}
-
-        for solver in data["solvers"]:
-            assert "id" in solver
-            assert "name" in solver
-            assert "image_name" in solver
-            assert "image_path" in solver
-            assert solver["image_name"] == "minizinc-solver"
-            assert (
-                solver["image_path"]
-                == "harbor.local/psp-solvers/minizinc-solver:latest"
-            )
+    for solver in data["solvers"]:
+        assert solver["image_name"] == "minizinc-solvers"
+        assert solver["image_path"] == IMAGE_URL
 
 
 def test_get_solver_by_id(authed_client_with_db, test_db):
-    """Test retrieving a specific solver by ID"""
-    fake_tarball = io.BytesIO(b"fake tar data")
+    _register(authed_client_with_db, names="chuffed")
 
-    with (
-        patch("src.routers.api.solvers.asyncio.create_subprocess_exec") as mock_exec,
-        patch("src.routers.api.solvers.get_harbor_credentials") as mock_creds,
-    ):
-        mock_creds.return_value = ("test-user", "test-pass")
-        mock_exec.return_value = create_mock_process(returncode=0)
+    solver = test_db.query(Solver).filter(Solver.name == "chuffed").first()
+    assert solver is not None
 
-        authed_client_with_db.post(
-            "/api/solverdirector/v1/solvers",
-            data={"image_name": "minizinc-solver", "names": "chuffed"},
-            files={"file": ("minizinc.tar", fake_tarball, "application/x-tar")},
-        )
-
-        solver = test_db.query(Solver).filter(Solver.name == "chuffed").first()
-        assert solver is not None
-
-        response = authed_client_with_db.get(f"/api/solverdirector/v1/solvers/{solver.id}")
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["id"] == solver.id
-        assert data["name"] == "chuffed"
-        assert data["image_name"] == "minizinc-solver"
-        assert data["image_path"] == "harbor.local/psp-solvers/minizinc-solver:latest"
+    response = authed_client_with_db.get(f"/api/solverdirector/v1/solvers/{solver.id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == solver.id
+    assert data["name"] == "chuffed"
+    assert data["image_name"] == "minizinc-solvers"
+    assert data["image_path"] == IMAGE_URL
 
 
 def test_get_solver_by_id_not_found(authed_client_with_db):
-    """Test retrieving a solver by ID that doesn't exist"""
     response = authed_client_with_db.get("/api/solverdirector/v1/solvers/99999")
-
     assert response.status_code == 404
     assert "not found" in response.json()["detail"]


### PR DESCRIPTION
## Summary
- Remove Harbor as the container registry and switch to GitHub Container Registry (ghcr.io)
- Delete `push_to_harbor.sh` scripts — images are now pushed to ghcr.io via CI
- Remove Harbor-related secrets, imagePullSecrets, and RBAC rules (public ghcr.io images need no pull credentials)
- Update solver registration to accept a registry URL directly instead of uploading a tarball

## Test plan
- [ ] CI passes
- [ ] `make start` no longer attempts to deploy Harbor
- [ ] `post-data-setup.sh` runs without Harbor dependencies
- [ ] Solver images register correctly via ghcr.io URL